### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,5 +8,5 @@ getM1CurrentMilliamps	KEYWORD2
 getM2CurrentMilliamps	KEYWORD2
 getM1Fault	KEYWORD2
 getM2Fault	KEYWORD2
-flipM1 KEYWORD2
-flipM2 KEYWORD2
+flipM1	KEYWORD2
+flipM2	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords