### PR TITLE
Make PWM work with Mega boards

### DIFF
--- a/DualG2HighPowerMotorShield.cpp
+++ b/DualG2HighPowerMotorShield.cpp
@@ -58,8 +58,8 @@ void DualG2HighPowerMotorShield::init()
   pinMode(_M2nFAULT, INPUT_PULLUP);
   pinMode(_M2CS, INPUT);
 
-#ifdef DUALG2HIGHPOWERMOTORSHIELD_TIMER1_AVAILABLE
-  if (_M1PWM == _M1PWM_TIMER1_PIN && _M2PWM == _M2PWM_TIMER1_PIN)
+#ifdef TIMER1_AVAILABLE_ON_9_AND_10
+  if (_M1PWM == _M1PWM_TIMER_PIN && _M2PWM == _M2PWM_TIMER_PIN)
   {
     // Timer 1 configuration
     // prescaler: clockI/O / 1
@@ -74,6 +74,24 @@ void DualG2HighPowerMotorShield::init()
     ICR1 = 400;
   }
 #endif
+
+#ifdef TIMER2_AVAILABLE_ON_9_AND_10
+  if (_M1PWM == _M1PWM_TIMER_PIN && _M2PWM == _M2PWM_TIMER_PIN)
+  {
+    // Timer 2 configuration for Mega boards
+    // prescaler: clockI/O / 1
+    // outputs enabled
+    // fast PWM
+    // top of 255
+    //
+    // PWM frequency calculation
+    // 16MHz / 8 (prescaler) / 1 (fast PWM) / 255 (top) = 7.8kHz
+    TCCR2A = 0b10100011; //11 in first two bits = fast PWM (could switch to phase correct PWM by making first two bits = 01, PWM frequency would be 3.9kHz)
+    TCCR2B = 0b00000010; //first 3 bits are prescaler
+    //ICR2 = 255;
+  }
+#endif
+
 }
 // Set speed for motor 1, speed is a number betwenn -400 and 400
 void DualG2HighPowerMotorShield::setM1Speed(int speed)
@@ -88,8 +106,8 @@ void DualG2HighPowerMotorShield::setM1Speed(int speed)
   if (speed > 400)  // Max PWM dutycycle
     speed = 400;
 
-#ifdef DUALG2HIGHPOWERMOTORSHIELD_TIMER1_AVAILABLE
-  if (_M1PWM == _M1PWM_TIMER1_PIN && _M2PWM == _M2PWM_TIMER1_PIN)
+#ifdef TIMERS_AVAILABLE
+  if (_M1PWM == _M1PWM_TIMER_PIN && _M2PWM == _M2PWM_TIMER_PIN)
   {
     OCR1A = speed;
   }
@@ -124,8 +142,8 @@ void DualG2HighPowerMotorShield::setM2Speed(int speed)
   if (speed > 400)  // Max
     speed = 400;
 
-#ifdef DUALG2HIGHPOWERMOTORSHIELD_TIMER1_AVAILABLE
-  if (_M1PWM == _M1PWM_TIMER1_PIN && _M2PWM == _M2PWM_TIMER1_PIN)
+#ifdef TIMERS_AVAILABLE
+  if (_M1PWM == _M1PWM_TIMER_PIN && _M2PWM == _M2PWM_TIMER_PIN)
   {
     OCR1B = speed;
   }

--- a/DualG2HighPowerMotorShield.cpp
+++ b/DualG2HighPowerMotorShield.cpp
@@ -109,7 +109,13 @@ void DualG2HighPowerMotorShield::setM1Speed(int speed)
 #ifdef TIMERS_AVAILABLE
   if (_M1PWM == _M1PWM_TIMER_PIN && _M2PWM == _M2PWM_TIMER_PIN)
   {
-    OCR1A = speed;
+    #ifdef TIMER1_AVAILABLE_ON_9_AND_10
+      OCR1A = speed;
+    #endif
+
+    #ifdef TIMER2_AVAILABLE_ON_9_AND_10
+      OCR2A = speed;
+    #endif
   }
   else
   {
@@ -145,7 +151,13 @@ void DualG2HighPowerMotorShield::setM2Speed(int speed)
 #ifdef TIMERS_AVAILABLE
   if (_M1PWM == _M1PWM_TIMER_PIN && _M2PWM == _M2PWM_TIMER_PIN)
   {
-    OCR1B = speed;
+    #ifdef TIMER1_AVAILABLE_ON_9_AND_10
+      OCR1B = speed;
+    #endif
+
+    #ifdef TIMER2_AVAILABLE_ON_9_AND_10
+      OCR2B = speed;
+    #endif
   }
   else
   {

--- a/DualG2HighPowerMotorShield.h
+++ b/DualG2HighPowerMotorShield.h
@@ -2,10 +2,19 @@
 
 #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || \
     defined(__AVR_ATmega328PB__) || defined (__AVR_ATmega32U4__) || \
-    defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega1280__) || \
-    defined(__AVR_ATmega2560__)
-  // Timer one is generally available for all boards.
-  #define DUALG2HIGHPOWERMOTORSHIELD_TIMER1_AVAILABLE
+    defined(__AVR_ATmega16U4__)
+  // Timer one (16 bit) on Pin 9 and 10 is generally available for all boards.
+  #define TIMER1_AVAILABLE_ON_9_AND_10
+#endif
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+  // Code in here will only be compiled if an Arduino Mega is used.
+  // Timer Two (8 bit) is used by Mega boards with Pin 9 and 10 due to hardware differences
+  #define TIMER2_AVAILABLE_ON_9_AND_10
+#endif
+
+#if defined(TIMER1_AVAILABLE_ON_9_AND_10) || defined(TIMER2_AVAILABLE_ON_9_AND_10)
+  // We have defined timers available for the board we are using
+  #define TIMERS_AVAILABLE
 #endif
 
 #include <Arduino.h>
@@ -55,27 +64,9 @@ class DualG2HighPowerMotorShield
 
   private:
     unsigned char _M1PWM;
-    #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || \
-        defined(__AVR_ATmega328PB__) || defined (__AVR_ATmega32U4__) || \
-        defined(__AVR_ATmega16U4__)
-        // Code in here will only be compiled if an Arduino Uno (or older), or Arduino Leonardo, Due is used.
-        static const unsigned char _M1PWM_TIMER1_PIN = 9;
-    #endif
-    #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-        // Code in here will only be compiled if an Arduino Mega is used.
-        static const unsigned char _M1PWM_TIMER1_PIN = 11;
-    #endif
+    static const unsigned char _M1PWM_TIMER_PIN = 9;
     unsigned char _M2PWM;
-    #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || \
-        defined(__AVR_ATmega328PB__) || defined (__AVR_ATmega32U4__) || \
-        defined(__AVR_ATmega16U4__)
-        // Code in here will only be compiled if an Arduino Uno (or older), or Arduino Leonardo, Due is used.
-        static const unsigned char _M2PWM_TIMER1_PIN = 10;
-    #endif
-    #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-        // Code in here will only be compiled if an Arduino Mega is used.
-        static const unsigned char _M2PWM_TIMER1_PIN = 12;
-    #endif
+    static const unsigned char _M2PWM_TIMER_PIN = 10;
     unsigned char _M1nSLEEP;
     unsigned char _M2nSLEEP;
     unsigned char _M1DIR;
@@ -86,7 +77,6 @@ class DualG2HighPowerMotorShield
     unsigned char _M2CS;
     static boolean _flipM1;
     static boolean _flipM2;
-
 };
 
 class DualG2HighPowerMotorShield24v14 : public DualG2HighPowerMotorShield

--- a/DualG2HighPowerMotorShield.h
+++ b/DualG2HighPowerMotorShield.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || \
-    defined(__AVR_ATmega328PB__) || defined (__AVR_ATmega32U4__)
+    defined(__AVR_ATmega328PB__) || defined (__AVR_ATmega32U4__) || \
+    defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega1280__) || \
+    defined(__AVR_ATmega2560__)
+  // Timer one is generally available for all boards.
   #define DUALG2HIGHPOWERMOTORSHIELD_TIMER1_AVAILABLE
 #endif
 
@@ -52,9 +55,27 @@ class DualG2HighPowerMotorShield
 
   private:
     unsigned char _M1PWM;
-    static const unsigned char _M1PWM_TIMER1_PIN = 9;
+    #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || \
+        defined(__AVR_ATmega328PB__) || defined (__AVR_ATmega32U4__) || \
+        defined(__AVR_ATmega16U4__)
+        // Code in here will only be compiled if an Arduino Uno (or older), or Arduino Leonardo, Due is used.
+        static const unsigned char _M1PWM_TIMER1_PIN = 9;
+    #endif
+    #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+        // Code in here will only be compiled if an Arduino Mega is used.
+        static const unsigned char _M1PWM_TIMER1_PIN = 11;
+    #endif
     unsigned char _M2PWM;
-    static const unsigned char _M2PWM_TIMER1_PIN = 10;
+    #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || \
+        defined(__AVR_ATmega328PB__) || defined (__AVR_ATmega32U4__) || \
+        defined(__AVR_ATmega16U4__)
+        // Code in here will only be compiled if an Arduino Uno (or older), or Arduino Leonardo, Due is used.
+        static const unsigned char _M2PWM_TIMER1_PIN = 10;
+    #endif
+    #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+        // Code in here will only be compiled if an Arduino Mega is used.
+        static const unsigned char _M2PWM_TIMER1_PIN = 12;
+    #endif
     unsigned char _M1nSLEEP;
     unsigned char _M2nSLEEP;
     unsigned char _M1DIR;


### PR DESCRIPTION
Timer one is on a different set of pins for Mega boards from Uno/Leonardo/Due Timer one pins
This PR makes PWM on timer one pins (11,12) work for Mega boards, **without breaking backward compatibility** for Uno/Leonardo/Due Timer one pins (9,10)

I have tested this change on a Mega and an Uno board with a modified version of this Library I'm working on for the Single G2 breakout boards (needed a library for the single boards for a project I'm working on) 

https://github.com/photodude/G2MotorDriver
If you're interested, I would be willing to transfer this modified library to pololu in a month or so when I'm no longer modifying the library with changes related to testing from my project. 